### PR TITLE
[ feat / fix ] 마이페이지 찜목록 UI 변경 및 더보기 버튼 추가하여 페이징 처리 기능 개발

### DIFF
--- a/tradeweb/src/components/footer/Footer.js
+++ b/tradeweb/src/components/footer/Footer.js
@@ -44,7 +44,7 @@ export default Footer;
 const Container = styled.div`
   width: 1280px;
   background-color: #ffffff;
-  margin-top: 1600px;
+  margin-top: 4000px;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   z-index: 999;
   display: flex;

--- a/tradeweb/src/components/userAccount/MyWishList.js
+++ b/tradeweb/src/components/userAccount/MyWishList.js
@@ -5,9 +5,13 @@ import { Box } from "@mui/material";
 
 const MyWishList = () => {
   const [responseData, setResponseData] = useState([]);
+  const [totalDataCounts, setTotalDataCounts] = useState(0); // 총 데이터 개수
+  const [page, setPage] = useState(1); // 현재 페이지
   const [showMore, setShowMore] = useState(false); // "더보기" 상태 관리
+  const [postPerPage, setPostPerPage] = useState(8); // 한 페이지에 보여줄 데이터 개수
   const token = localStorage.getItem("accessToken");
   const userId = localStorage.getItem("userId");
+
 
   useEffect(() => {
     async function get() {
@@ -23,6 +27,7 @@ const MyWishList = () => {
         );
         console.log("응답 데이터:", response.data.products);
         setResponseData(response.data.products);
+        setTotalDataCounts(response.data.products.length);
       } catch (error) {
         console.error("요청 실패:", error);
       }
@@ -61,9 +66,21 @@ const MyWishList = () => {
     }
   };
 
+  // 총 페이지 수 계산
+  const totalPages = Math.ceil(totalDataCounts / postPerPage);
+
+  // 현재 페이지에 맞는 데이터 계산
+  const indexOfLastPost = page * postPerPage;
+  const indexOfFirstPost = indexOfLastPost - postPerPage;
+  const currentPosts = responseData.slice(indexOfFirstPost, indexOfLastPost);
+
   // "더보기" 버튼 클릭 시 상태 변경
   const handleShowMoreClick = () => {
-    setShowMore(!showMore);
+    if (page < totalPages) {
+      setPage(prevPage => prevPage + 1);
+    } else {
+      setShowMore(!showMore);
+    }
   };
 
   return (

--- a/tradeweb/src/components/userAccount/MyWishList.js
+++ b/tradeweb/src/components/userAccount/MyWishList.js
@@ -12,6 +12,23 @@ const MyWishList = () => {
   const token = localStorage.getItem("accessToken");
   const userId = localStorage.getItem("userId");
 
+   // 총 페이지 수 계산
+   const totalPages = Math.ceil(totalDataCounts / postPerPage);
+
+   // 현재 페이지에 맞는 데이터 계산
+   const indexOfLastPost = page * postPerPage;
+   const indexOfFirstPost = indexOfLastPost - postPerPage;
+   const currentPosts = responseData.slice(indexOfFirstPost, indexOfLastPost);
+ 
+   // "더보기" 버튼 클릭 시 상태 변경
+   const handleShowMoreClick = () => {
+     if (page < totalPages) {
+       setPage(prevPage => prevPage + 1);
+     } else {
+       setShowMore(!showMore);
+     }
+   };
+ 
 
   useEffect(() => {
     async function get() {
@@ -35,7 +52,7 @@ const MyWishList = () => {
     if (userId && token) {
       get();
     }
-  }, [userId, token]);
+  }, [page, userId, token, postPerPage]);
 
   const dislikeClick = (productId) => {
     console.log("disLikeProductId: ", productId);
@@ -66,23 +83,7 @@ const MyWishList = () => {
     }
   };
 
-  // 총 페이지 수 계산
-  const totalPages = Math.ceil(totalDataCounts / postPerPage);
-
-  // 현재 페이지에 맞는 데이터 계산
-  const indexOfLastPost = page * postPerPage;
-  const indexOfFirstPost = indexOfLastPost - postPerPage;
-  const currentPosts = responseData.slice(indexOfFirstPost, indexOfLastPost);
-
-  // "더보기" 버튼 클릭 시 상태 변경
-  const handleShowMoreClick = () => {
-    if (page < totalPages) {
-      setPage(prevPage => prevPage + 1);
-    } else {
-      setShowMore(!showMore);
-    }
-  };
-
+ 
   return (
     <Box sx={{ p: 3 }}>
       <Wrapper>

--- a/tradeweb/src/components/userAccount/MyWishList.js
+++ b/tradeweb/src/components/userAccount/MyWishList.js
@@ -1,189 +1,236 @@
-import React, {useEffect,  useState} from 'react';
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import plus from "../../assets/plus.svg";
-import {Box } from "@mui/material";
+import { Box } from "@mui/material";
 
 const MyWishList = () => {
-    const [responseData, setResponseData] = useState([]);
-    const token = localStorage.getItem("accessToken");
-    const userId = localStorage.getItem("userId");
-    const [productId, setProductId] = useState(0);
+  const [responseData, setResponseData] = useState([]);
+  const [showMore, setShowMore] = useState(false); // "더보기" 상태 관리
+  const token = localStorage.getItem("accessToken");
+  const userId = localStorage.getItem("userId");
 
-
-    useEffect(() => {
-        async function get() {
-            try {
-                const response = await axios.get(`${process.env.REACT_APP_API_URL}likes/user/${userId}`, {
-                    headers: {
-                        'Content-Type': "multipart/form-data",
-                        'Authorization': `Bearer ${token}`,
-                    }
-                });
-                console.log("응답 데이터:", response.data.products);
-                setResponseData(response.data.products)
-               
-            } catch (error) {
-                console.error("요청 실패:", error);
-            }
-        };
-        if (userId && token) {
-            get();
-        }
-    }, [userId, token]); 
-
-    const dislikeClick = (productId) => {
-        console.log("disLikeProductId: ", productId);
-        setResponseData(responseData.filter(product => product.productId !== productId));
-        sendDisLikeProductId(productId);
+  useEffect(() => {
+    async function get() {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_API_URL}likes/user/${userId}`,
+          {
+            headers: {
+              "Content-Type": "multipart/form-data",
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+        console.log("응답 데이터:", response.data.products);
+        setResponseData(response.data.products);
+      } catch (error) {
+        console.error("요청 실패:", error);
+      }
     }
-
-    const sendDisLikeProductId = async (productId) => {
-        try {
-            const response = await axios.post(`${process.env.REACT_APP_API_URL}likes`, 
-                {
-                    productId: productId,
-                },
-                {
-                    headers: {
-                        'Content-Type': "multipart/form-data",
-                        'Authorization': `Bearer ${token}`,
-                    },
-                });
-            console.log("응답 데이터:", response.data.products);
-            setResponseData(response.data.products);
-        } catch (error) {
-            console.error("요청 실패:", error);
-        }
+    if (userId && token) {
+      get();
     }
+  }, [userId, token]);
 
-
-    return (
-        <Box sx={{ p: 3 }}>
-            <Wrapper>
-                <Container>
-                    <Title>찜목록</Title>
-                    <SearchResultList>
-                        {responseData.length > 0 ?  responseData.map((product) => (
-                            <SearchItem key={product.productId}>
-                                <ItemImageBox>
-                                    <ItemImage src={`${process.env.REACT_APP_IMAGE_URL}${product.imageUrl}`} alt={product.productName} />
-                                </ItemImageBox>
-                                <ItemTitle>{product.productName}</ItemTitle>
-                                <ItemPrice>
-                                    {product.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                                </ItemPrice>
-                                <HeartIcon onClick={() => dislikeClick(product.productId)}>❤️</HeartIcon>
-                            
-                            </SearchItem>
-                            
-                        )) : <h1>찜한 상품이 없습니다</h1>}
-                    
-                    </SearchResultList>
-                </Container>
-                <GetLikeMoreButton>더보기</GetLikeMoreButton>
-                
-            </Wrapper>
-            
-        </Box>
+  const dislikeClick = (productId) => {
+    console.log("disLikeProductId: ", productId);
+    setResponseData(
+      responseData.filter((product) => product.productId !== productId)
     );
+    sendDisLikeProductId(productId);
+  };
+
+  const sendDisLikeProductId = async (productId) => {
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_URL}likes`,
+        {
+          productId: productId,
+        },
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+            Authorization: `Bearer ${token}`,
+          }
+        }
+      );
+      console.log("응답 데이터:", response.data.products);
+      setResponseData(response.data.products);
+    } catch (error) {
+      console.error("요청 실패:", error);
+    }
+  };
+
+  // "더보기" 버튼 클릭 시 상태 변경
+  const handleShowMoreClick = () => {
+    setShowMore(!showMore);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Wrapper>
+        <Container>
+          <Title>찜목록</Title>
+          <SearchResultList>
+            {responseData.length > 0 ? (
+              responseData
+                .slice(0, showMore ? responseData.length : 8) // "더보기" 기능: 8개씩 보여줌
+                .map((product) => (
+                  <SearchItem key={product.productId}>
+                    <ItemImageBox>
+                      <ItemImage
+                        src={`${process.env.REACT_APP_IMAGE_URL}${product.imageUrl}`}
+                        alt={product.productName}
+                      />
+                    </ItemImageBox>
+                    <ItemTitle>{product.productName}</ItemTitle>
+                    <ItemPrice>
+                      {product.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+                    </ItemPrice>
+                    <HeartIcon onClick={() => dislikeClick(product.productId)}>
+                      ❤️
+                    </HeartIcon>
+                  </SearchItem>
+                ))
+            ) : (
+              <h1>찜한 상품이 없습니다</h1>
+            )}
+          </SearchResultList>
+          {/* "더보기" 버튼 */}
+          {responseData.length >= 8 && ( // 총 아이템 수가 8개 이상일 경우에만 버튼을 보여줌
+            <GetLikeMoreButton onClick={handleShowMoreClick}>
+              {showMore ? "접기" : "더보기"}
+            </GetLikeMoreButton>
+          )}
+        </Container>
+      </Wrapper>
+    </Box>
+  );
 };
 
 export default MyWishList;
 
 const Wrapper = styled.div`
-    display: flex;
-    flex-direction: row;
+  display: flex;
+  flex-direction: row;
 `;
 
 const Container = styled.div`
-    width: 1230px;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
 `;
 
-const Title  = styled.div`
-    margin-top: 20px;
-    margin-bottom: 20px;
-    font-size: 24px;
-    font-weight: bold;
+const Title = styled.div`
+  margin-top: 20px;
+  margin-bottom: 20px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
 `;
-
 
 const SearchResultList = styled.div`
-    height: 200px;
-    row-gap: 40px;
-    display: grid;
-    row-gap: 140px;
-    column-gap: 40px;
-    grid template-comumns: 200px 200px 200px 200px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr); /* 4열 */
+  grid-template-rows: repeat(2, 1fr); /* 2행 */
+  gap: 40px 20px; /* 행 간격: 40px, 열 간격: 20px */
+  padding: 0 20px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(2, 1fr); /* 화면이 작아지면 2열 */
+    grid-template-rows: repeat(4, 1fr); /* 4행 */
+  }
 `;
 
 const SearchItem = styled.div`
-    width: 200px;
-    height: 200px;
+  border: 1px solid red;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
 `;
 
 const ItemImageBox = styled.div`
-    border-radius: 10px;
+  width: 100%;
+  height: 150px; /* 이미지 박스 높이 고정 */
+  border-radius: 10px;
+  overflow: hidden; /* 이미지가 박스를 넘지 않도록 설정 */
+  margin-bottom: 10px;
 `;
+
 const ItemImage = styled.img`
-    width: 200px;
-    height:200px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover; /* 이미지 비율을 유지하며 박스에 맞춤 */
 `;
 
 const ItemTitle = styled.div`
-    width: 120px;
-    font-weight: bold;
-    margin-bottom: 20px;
-`;
-
-const ItemInfo = styled.div`
-    width: 120px;
-    height: 24px;
-    font-size: 14px;
-    margin-bottom: 20px;
+  font-weight: bold;
+  font-size: 16px;
+  text-align: center;
+  margin-bottom: 5px;
 `;
 
 const ItemPrice = styled.div`
-    font-weight: bold;
-    margin-bopttom: 20px;
+  font-weight: bold;
+  font-size: 16px;
+  color: #333;
+  margin-bottom: 10px;
 `;
+
 const HeartIcon = styled.div`
-    margin-right: 5px;
-    margin-bottom: 20px;
-    cursor:pointer;
+  margin-right: 5px;
+  cursor: pointer;
+  font-size: 20px;
+  color: #e74c3c;
 `;
 
 const GetLikeMoreButton = styled.button`
-     margin-top: 200px;
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  transition: background-color 0.3s;
 
+  &:hover {
+    background-color: #2980b9;
+  }
 `;
 
 const Pagination = styled.div``;
 
 const PageButton = styled.button`
-    width: 35px;
-    height: 35px;
-    background-color: black;
-    color: white;
-    cursor: pointer;
+  width: 35px;
+  height: 35px;
+  background-color: black;
+  color: white;
+  cursor: pointer;
+  margin: 5px;
 `;
 
 const InterestsWrapper = styled.div`
-    width: 644px;
-    height: 40px;
-    dispaly: flex;
+  width: 644px;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 20px;
 `;
 
 const Interest = styled.div`
-    width: 50px;
-    height: 20px;
-    border-radius: 40px;
-    background-color: white;
-    color: black;
-    border: 1px solid #D1D4D8;
-    text-align: center;
+  width: 50px;
+  height: 20px;
+  border-radius: 40px;
+  background-color: white;
+  color: black;
+  border: 1px solid #d1d4d8;
+  text-align: center;
+  line-height: 20px;
+  font-size: 12px;
 `;


### PR DESCRIPTION
#147
##구현 기능
- [x] 마이페이지 찜 탭 찜목록 카드리스트 형식으로 보여질 수 있도록 UI 수정
- [x] 마이페이지 찜목록 더보기 버튼 UI 디자인 추가
- [x] 마이페이지 찜목록 UI 그리드 사용하여 수정
- [x] 찜 데이터 개수가 8개 이상 넘어가는 경우 더보기 버튼을 눌렀을때 데이터 랜더링 되도록 함

##상세 작업
그리드 columns 사용해서 한행에 200px 데이터가 4개씩 들어오도록 코드 수정
찜개수가 8개 이상인 경우 더보기 버튼을 클릭하여 더 볼 수 있도록 더보기  버튼 UI 추가
더보기 버튼 상태를 관리할 수 있는 상태 변수 추가 (더보기 버튼을 무조건 보여주면 안되고 남은 데이터가 있는 경우에만 보여줘야 하기 때문이다)
더보기 버튼으로 페이징 처리를 하기 위해 총 데이터 개수를 관리하는 상태 변수 추가
한 페이지에 보여줄 데이터 개수를 관리하는 상태 변수 추가
더보기 버튼 클릭시 현재 페이지 번호가 전체 페이지 번호보다 작은 경우에만 현재페이지를 이전페이지 번호 + 1 시키는 조건문 추가
이외의 경우 더보기 버튼 비활성화 처리 


##스크린샷
![image](https://github.com/user-attachments/assets/6ab260eb-6f58-4266-9e7e-631c9f454fed)
![image](https://github.com/user-attachments/assets/b83bd710-3aa3-4418-bc70-1a3017f095cb)


##코멘트