### PR TITLE
[ feat / fix  ]마이페이지 구매내역 UI 데이러 랜더링 수정

### DIFF
--- a/tradeweb/src/components/payment/UserPayment.js
+++ b/tradeweb/src/components/payment/UserPayment.js
@@ -32,7 +32,7 @@ const UserPayment = () => {
                         }
                     }
                 ).then(function (response) {
-                    const purchasesArray = response.data;
+                    const purchasesArray = response.data.products;
                     setResponseData(purchasesArray);
                     console.log("responseData: ", responseData);
                 })

--- a/tradeweb/src/components/payment/UserSellHistory.js
+++ b/tradeweb/src/components/payment/UserSellHistory.js
@@ -5,78 +5,97 @@ import Pagination from "../pagination/Pagination";
 
 const UserSellHistory = () => {
     const [loading, setLoading] = useState(false);
-    const [postsPerPage, setPostsPerPage] = useState(8);// 한페이지에 8개의 상품을 보여준다
-    const [currentPage, setCurrentPage] = useState(1); //현재페이지
+    const [postsPerPage, setPostsPerPage] = useState(8); // 한 페이지에 8개의 상품을 보여준다
+    const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
     const token = localStorage.getItem("accessToken");
     const userId = localStorage.getItem("userId");
-    const [responseData, setResponseData] = useState([]);
-    const apiUrl = `${process.env.REACT_APP_API_URL}purchase/user/${userId}`;
+    const [responseData, setResponseData] = useState([]); // 초기값을 빈 배열로 설정
 
     useEffect(() => {
+        const apiUrl = `${process.env.REACT_APP_API_URL}purchase/user/${userId}?page=${currentPage}&size=${postsPerPage}&sort=desc`;
+
         async function get() {
             setLoading(true);
             try {
-                await axios.get(apiUrl,
-                    {
-                        headers: {
-                            'Content-Type': "multipart/form-data",
-                            'Authorization': `Bearer ${token}`,
-                        },
-                        params: {
-                            "page": 1,
-                            "size": 10,
-                            "sort": "desc"
-                        }
-                    }
-                ).then(function (response) {
-                    const purchasesArray = response.data;
-                    setResponseData(purchasesArray);
-                    console.log("responseData: ", responseData);
-                })
+                const response = await axios.get(apiUrl, {
+                    headers: {
+                        'Content-Type': "multipart/form-data",
+                        'Authorization': `Bearer ${token}`,
+                    },
+                });
+
+                console.log("API 응답 데이터: ", response);
+                console.log("API 응답 데이터: ", response.data.products);
+
+                // 서버 응답 형식이 배열인지 확인
+                if (Array.isArray(response.data)) {
+                    setResponseData(response.data.products);
+                } else if (response.data.data && Array.isArray(response.data.data)) {
+                    // 만약 데이터가 { data: [...] } 형식이라면
+                    setResponseData(response.data.data);
+                } else {
+                    console.error("배열이 아닌 데이터가 반환되었습니다: ", response.data);
+                    setResponseData([]); // 안전하게 빈 배열로 초기화
+                }
+
             } catch (error) {
                 console.log("요청 실패: ", error);
                 if (error.response) {
                     console.log('Error data:', error.response.data);
                     console.log('Error status:', error.response.status);
                     console.log('Error headers:', error.response.headers);
+                } else {
+                    console.error("기타 오류: ", error.message);
                 }
             } finally {
                 setLoading(false);
             }
+        }
 
-        };
         get();
-    }, [apiUrl, token, currentPage])
+    }, [token, currentPage, postsPerPage]);
 
-    const paginate =(currentPage) => setCurrentPage(currentPage);
+    // 상태 업데이트 확인
+    useEffect(() => {
+        console.log("업데이트된 responseData: ", responseData);
+    }, [responseData]);
 
-  return (
-    <>
-        <Container>
+    const paginate = (currentPage) => setCurrentPage(currentPage);
+
+    return (
+        <>
+            <Container>
                 <Title>판매 내역</Title>
                 <Table>
-                <tr>
-                    <TableTh>상품 이미지</TableTh>
-                    <TableTh>상품명</TableTh>
-                    <TableTh>금액</TableTh>
-                    <TableTh>판매자 닉네임</TableTh>
-                </tr>
-                <tbody>
-                        {responseData.map((data, index) => (
-                            <tr key={index}>
-                                <TableTd><img src={data.imageUrl} alt="product" /></TableTd>
-                                <TableTd>{data.productName}</TableTd>
-                                <TableTd>{data.price}</TableTd>
-                                <TableTd>{data.sellerNickname}</TableTd>
+                    <thead>
+                        <tr>
+                            <TableTh>상품 이미지</TableTh>
+                            <TableTh>상품명</TableTh>
+                            <TableTh>금액</TableTh>
+                            <TableTh>판매자 닉네임</TableTh>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {Array.isArray(responseData) && responseData.length > 0 ? (
+                            responseData.map((data, index) => (
+                                <tr key={index}>
+                                    <TableTd><img src={data.imageUrl} alt="product" /></TableTd>
+                                    <TableTd>{data.productName}</TableTd>
+                                    <TableTd>{data.price}</TableTd>
+                                    <TableTd>{data.sellerNickname}</TableTd>
+                                </tr>
+                            ))
+                        ) : (
+                            <tr>
+                                <TableTd colSpan={4}>데이터가 없습니다.</TableTd>
                             </tr>
-                        ))}
+                        )}
                     </tbody>
                 </Table>
-                <Pagination  totalPosts={responseData.length} postsPerPage={postsPerPage} setCurrentPage={currentPage}  paginate={paginate}  />  
-           
+                <Pagination totalPosts={responseData.length} postsPerPage={postsPerPage} setCurrentPage={currentPage} paginate={paginate} />
             </Container>
         </>
-    )
+    );
 }
 
 export default UserSellHistory;
@@ -88,7 +107,7 @@ const Container = styled.div`
     align-items: center;
 `;
 
-const Title  = styled.div`
+const Title = styled.div`
     margin-top: 20px;
     margin-bottom: 20px;
     font-size: 24px;

--- a/tradeweb/src/components/review/ReviewRegister.js
+++ b/tradeweb/src/components/review/ReviewRegister.js
@@ -33,7 +33,7 @@ const renderStars = (rating) => {
   return stars;
 };
 
-const Review = () => {
+const ReviewRegister = () => {
   const [isPurchased, setIsPurchased] = useState(true);
   const [reviewContent, setReviewContent] = useState("");
   const [listData, setListData] = useState([]);
@@ -49,6 +49,7 @@ const Review = () => {
   const token = localStorage.getItem("accessToken");
   const [sellerInfo, setSellerInfo] = useState({});
 
+  // 상품에 대한 리뷰
   const fetchReviews = async () => {
     try {
       const reviewResponse = await axios.get(
@@ -61,11 +62,12 @@ const Review = () => {
       );
       const reviews = reviewResponse.data;
       setReviews(reviews);
-      console.log(reviews);
+      console.log("reviews: " , reviews);
 
       const sellerId = reviews?.[0]?.sellerId;
 
       if (sellerId) {
+        // 판매자에 대한 리뷰
         const sellerResponse = await axios.get(
           `${process.env.REACT_APP_API_URL}reviews/seller/${sellerId}`,
           {
@@ -74,6 +76,7 @@ const Review = () => {
             },
           }
         );
+
         const sellerData = sellerResponse.data;
         setSellerInfo({
           sellerImage: sellerData.sellerProfileImageUrl,
@@ -83,10 +86,6 @@ const Review = () => {
           ratedCount: sellerData.totalReviews,
         });
         console.log(sellerData);
-
-        for (let i = 0; i < sellerData.length; i++) {
-           averageRating[i] = sellerData[i].rating;
-        }
       } else {
         console.warn("No sellerId found in reviews.");
       }
@@ -141,7 +140,7 @@ const Review = () => {
       setListData((prev) => [...prev, ...newReviews]);
       setPage((prev) => prev + 1);
     }
-  }, [page, reviews]);
+  }, [page, reviews, productId]);
 
   useEffect(() => {
     fetchReviews();
@@ -206,10 +205,10 @@ const Review = () => {
                 ))}
               </div>
             </ReviewIconWrapper>
-            {/* <AverageText>
+            <AverageText>
               {averageRating} / 5 <p>({totalReviews})</p>
-            </AverageText> */}
-            {/* <StarAverage>{renderStars(parseFloat(averageRating))}</StarAverage> */}
+            </AverageText>
+            <StarAverage>{renderStars(parseFloat(averageRating))}</StarAverage>
             <InputElement
               type="text"
               value={reviewContent}
@@ -222,11 +221,13 @@ const Review = () => {
             상품 구매후에 후기를 작성할 수 있습니다
           </ReviewWriteContainer>
         )}
-        {listData.map((data, index) => (
+        {reviews.map((data, index) => (
           <ProfileContainer key={index}>
             <ReviewHeader>
-              <img src={data.files} alt="profile" />
-              <div>{data.nickName}</div>
+              {/* <img src={data.reviewerProfileImageUrl} alt="profile" /> */}
+              <div>{data.reviewerNickname}</div>
+              <div>{data.productName}</div>
+              <div>{data.reviewContent}</div>
               <div>{data.date}</div>
             </ReviewHeader>
             <StarContainer>
@@ -266,7 +267,7 @@ const Review = () => {
   );
 };
 
-export default Review;
+export default ReviewRegister;
 
 const Wrapper = styled.div`
   display: flex;


### PR DESCRIPTION
- [x] 마이페이지 구매내역 데이터 랜더링 UI 수정
- [x] - [x]  내가 구매한 상품 목록이 상품 목록 탭에 table에 데이터가 랜더링 되도록 기능 개발

##상세 작업
프록시를 사용하여 로컬 서버에서 CORS를 우회 시켰다
http-proxy-middleware 패키지를 설치했다
구매한 상품목록 GET API 요청을 통해 받은 데이터를 table에 랜더링 시켜줬다


##스크린샷
![image](https://github.com/user-attachments/assets/c5271a8b-ca2a-4592-b4a5-d24d62395c1d)
